### PR TITLE
Remove HotModuleReplacement in example

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
   },
   "rules": {
     "no-var": 0,
-    "no-console": 0
+    "no-console": 0,
+    "no-process-env": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "build:lib": "babel -sd lib src",
     "build:example": "webpack",
     "prepublish": "npm run build",
-    "start": "webpack-dev-server --history-api-fallback",
+    "start": "NODE_ENV='development' webpack-dev-server --history-api-fallback",
     "lint": "eslint ./src ./*.js",
     "test": "npm run lint",
-    "check": "npm run build"
+    "check": "npm run lint && npm run build"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var path = require('path');
+var env = process.env.NODE_ENV || 'production';
 
 
 var eslintLoader = {
@@ -15,10 +16,11 @@ module.exports = {
   devtool: 'eval',
 
   entry: [
-    './src/example/Example.js',
-    'webpack-dev-server/client?http://localhost:8080',
-    'webpack/hot/only-dev-server'
-  ],
+    './src/example/Example.js'
+  ].concat(env === 'production' ? [] : [
+      'webpack-dev-server/client?http://localhost:8080',
+      'webpack/hot/only-dev-server'
+    ]),
 
   output: {
     filename: 'index.js',
@@ -27,9 +29,15 @@ module.exports = {
 
   plugins: [
     new HtmlWebpackPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
-    new ExtractTextPlugin('style.css', {allChunks: true})
-  ],
+    new ExtractTextPlugin('style.css', {allChunks: true}),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"' + env + '"'
+      }
+    })
+  ].concat(env === 'production' ? [] : [
+      new webpack.HotModuleReplacementPlugin()
+    ]),
 
   module: {
     loaders: [
@@ -44,7 +52,7 @@ module.exports = {
           'css?modules&sourceMap&localIdentName=[name]__[local]___[hash:base64:5]')
       }
     ],
-    preLoaders: [
+    preLoaders: env === 'production' ? [] : [
       eslintLoader
     ]
   },
@@ -57,6 +65,7 @@ module.exports = {
   stats: {
     colors: true
   },
+
 
   eslint: {
     configFile: 'src/.eslintrc',


### PR DESCRIPTION
Also removed ESLint loader for production build. Code validation should be done with `npm run lint`